### PR TITLE
[Fix] Accept RFC violations related to dots refs#134046

### DIFF
--- a/MimeKit/InternetAddress.cs
+++ b/MimeKit/InternetAddress.cs
@@ -294,7 +294,7 @@ namespace MimeKit {
 			localpart = null;
 
 			do {
-				if (!text[index].IsAtom () && text[index] != '"') {
+				if (!text[index].IsAtom () && text[index] != '"' && text[index] != '.') {
 					if (throwOnError)
 						throw new ParseException (string.Format ("Invalid local-part at offset {0}", startIndex), startIndex, index);
 
@@ -302,7 +302,7 @@ namespace MimeKit {
 				}
 
 				int start = index;
-				if (!ParseUtils.SkipWord (text, ref index, endIndex, throwOnError))
+				if (!ParseUtils.SkipWordAndPeriod (text, ref index, endIndex, throwOnError))
 					return false;
 
 				try {
@@ -332,6 +332,10 @@ namespace MimeKit {
 
 					return false;
 				}
+
+				if (text[index] == '@')
+					break;
+				
 			} while (true);
 
 			localpart = token.ToString ();
@@ -596,7 +600,8 @@ namespace MimeKit {
 							trimLeadingQuote = true;
 					}
 				} else {
-					if (!ParseUtils.SkipAtom (text, ref index, endIndex))
+
+					if (!ParseUtils.SkipWordAndPeriod (text, ref index, endIndex, throwOnError))
 						break;
 				}
 

--- a/MimeKit/Utils/ParseUtils.cs
+++ b/MimeKit/Utils/ParseUtils.cs
@@ -222,6 +222,18 @@ namespace MimeKit.Utils {
 			return true;
 		}
 
+		public static bool SkipPeriod (byte [] text, ref int index, int endIndex)
+		{
+			int start = index;
+
+			while (index < endIndex && text [index] == (byte)'.')
+				index++;
+
+			index--;
+
+			return index >= start;
+		}
+
 		public static bool SkipAtom (byte[] text, ref int index, int endIndex)
 		{
 			int start = index;
@@ -249,6 +261,20 @@ namespace MimeKit.Utils {
 
 			if (text[index].IsAtom ())
 				return SkipAtom (text, ref index, endIndex);
+
+			return false;
+		}
+
+		public static bool SkipWordAndPeriod (byte[] text, ref int index, int endIndex, bool throwOnError)
+		{
+			if (text[index] == (byte) '"')
+				return SkipQuoted (text, ref index, endIndex, throwOnError);
+
+			if (text[index].IsAtom ())
+				return SkipAtom (text, ref index, endIndex);
+
+			if (text[index] == (byte) '.')
+				return SkipPeriod (text, ref index, endIndex);
 
 			return false;
 		}

--- a/UnitTests/InternetAddressTests.cs
+++ b/UnitTests/InternetAddressTests.cs
@@ -423,5 +423,134 @@ namespace UnitTests {
 		}
 
 		#endregion
+
+		#region TestLegacyEmailAddress
+		TestCaseData[] LegacyAddressNotCompliantWithRFC ()
+		{
+			var addressList = new TestCaseData[]
+			{
+				// RFCCompliance
+				new TestCaseData ("aaaa@example.com"),
+				new TestCaseData ("aa.aa@example.com"),
+				new TestCaseData ("0123456789@example.com"),
+				new TestCaseData ("abcdefghijklmnopqrstuvwxyz@example.com"),
+				new TestCaseData ("ABCDEFGHIJKLMNOPQRSTUVWXYZ@example.com"),
+				new TestCaseData ("a.a-a_a@ex-amp_le.com"),
+				new TestCaseData ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com"),
+				new TestCaseData ("アドレス <aaaa@example.com>"),
+				new TestCaseData ("アドレス<aaaa@example.com>"),
+				new TestCaseData ("\"アドレス\" <aaaa@example.com>"),
+				new TestCaseData ("\"アドレス\"   <aaaa@example.com>"),
+				new TestCaseData ("\"アドレス\"<aaaa@example.com>"),
+				new TestCaseData ("aaaa@example.com (アドレス)"),
+				new TestCaseData ("aaaa@example.com   (アドレス)"),
+				new TestCaseData ("aaaa@example.com(アドレス)"),
+				new TestCaseData ("0123456789 <aaaa@example.com>"),
+				new TestCaseData ("abcdefghijklmnopqrstuvwxyz <aaaa@example.com>"),
+				new TestCaseData ("ABCDEFGHIJKLMNOPQRSTUVWXYZ <aaaa@example.com>"),
+				new TestCaseData ("a.a@a-a_a <aaaa@example.com>"),
+				new TestCaseData ("bbb@example.com <aaaa@example.com>"),
+				new TestCaseData ("%22%3E%3C%28%29%5C <aaaa@example.com>"),
+				new TestCaseData ("\"%22%3E%3C%28%29%5C\" <aaaa@example.com>"),
+				new TestCaseData ("aaaa@example.com (%22%3E%3C%28%29%5C)"),
+				new TestCaseData ("aa!aa@example.com"),
+				new TestCaseData ("aa#aa@example.com"),
+				new TestCaseData ("aa$aa@example.com"),
+				new TestCaseData ("aa%aa@example.com"),
+				new TestCaseData ("aa&aa@example.com"),
+				new TestCaseData ("aa'aa@example.com"),
+				new TestCaseData ("aa*aa@example.com"),
+				new TestCaseData ("aa+aa@example.com"),
+				new TestCaseData ("aa/aa@example.com"),
+				new TestCaseData ("aa=aa@example.com"),
+				new TestCaseData ("aa?aa@example.com"),
+				new TestCaseData ("aa^aa@example.com"),
+				new TestCaseData ("aa`aa@example.com"),
+				new TestCaseData ("aa{aa@example.com"),
+				new TestCaseData ("aa|aa@example.com"),
+				new TestCaseData ("aa}aa@example.com"),
+				new TestCaseData ("aa~aa@example.com"),
+				new TestCaseData ("aa%20aa@example.com"),
+				new TestCaseData ("aa%21aa@example.com"),
+				new TestCaseData ("aa%23aa@example.com"),
+				new TestCaseData ("aa%24aa@example.com"),
+				new TestCaseData ("aa%25aa@example.com"),
+				new TestCaseData ("aa%26aa@example.com"),
+				new TestCaseData ("aa%27aa@example.com"),
+				new TestCaseData ("aa%2Aaa@example.com"),
+				new TestCaseData ("aa%2Baa@example.com"),
+				new TestCaseData ("aa%2Faa@example.com"),
+				new TestCaseData ("aa%3Daa@example.com"),
+				new TestCaseData ("aa%3Faa@example.com"),
+				new TestCaseData ("aa%5Eaa@example.com"),
+				new TestCaseData ("aa%60aa@example.com"),
+				new TestCaseData ("aa%7Baa@example.com"),
+				new TestCaseData ("aa%7Caa@example.com"),
+				new TestCaseData ("aa%7Daa@example.com"),
+				new TestCaseData ("aa%7Eaa@example.com"),
+				new TestCaseData ("aa%00aa@example.com"),
+				new TestCaseData ("aa%7Faa@example.com"),
+				new TestCaseData ("アドレス <aa!aa@example.com>"),
+				new TestCaseData ("アドレス <aa#aa@example.com>"),
+				new TestCaseData ("アドレス <aa$aa@example.com>"),
+				new TestCaseData ("アドレス <aa%aa@example.com>"),
+				new TestCaseData ("アドレス <aa&aa@example.com>"),
+				new TestCaseData ("アドレス <aa'aa@example.com>"),
+				new TestCaseData ("アドレス <aa*aa@example.com>"),
+				new TestCaseData ("アドレス <aa+aa@example.com>"),
+				new TestCaseData ("アドレス <aa/aa@example.com>"),
+				new TestCaseData ("アドレス <aa=aa@example.com>"),
+				new TestCaseData ("アドレス <aa?aa@example.com>"),
+				new TestCaseData ("アドレス <aa^aa@example.com>"),
+				new TestCaseData ("アドレス <aa`aa@example.com>"),
+				new TestCaseData ("アドレス <aa{aa@example.com>"),
+				new TestCaseData ("アドレス <aa|aa@example.com>"),
+				new TestCaseData ("アドレス <aa}aa@example.com>"),
+				new TestCaseData ("アドレス <aa~aa@example.com>"),
+				new TestCaseData ("アドレス <aa%21aa@example.com>"),
+				new TestCaseData ("アドレス <aa%22aa@example.com>"),
+				new TestCaseData ("アドレス <aa%23aa@example.com>"),
+				new TestCaseData ("アドレス <aa%24aa@example.com>"),
+				new TestCaseData ("アドレス <aa%25aa@example.com>"),
+				new TestCaseData ("アドレス <aa%26aa@example.com>"),
+				new TestCaseData ("アドレス <aa%27aa@example.com>"),
+				new TestCaseData ("アドレス <aa%2Aaa@example.com>"),
+				new TestCaseData ("アドレス <aa%2Baa@example.com>"),
+				new TestCaseData ("アドレス <aa%2Faa@example.com>"),
+				new TestCaseData ("アドレス <aa%3Daa@example.com>"),
+				new TestCaseData ("アドレス <aa%3Faa@example.com>"),
+				new TestCaseData ("アドレス <aa%5Eaa@example.com>"),
+				new TestCaseData ("アドレス <aa%60aa@example.com>"),
+				new TestCaseData ("アドレス <aa%7Baa@example.com>"),
+				new TestCaseData ("アドレス <aa%7Caa@example.com>"),
+				new TestCaseData ("アドレス <aa%7Daa@example.com>"),
+				new TestCaseData ("アドレス <aa%7Eaa@example.com>"),
+				new TestCaseData ("\"アド<>レス\" <aaaa@example.com>"),
+				new TestCaseData ("\"アド()レス\" <aaaa@example.com>"),
+				new TestCaseData ("ADDRESS012345"),
+				new TestCaseData ("アドレス０１２３４５"),
+
+				// Not compliant with RFC
+				new TestCaseData ("aaaa.@example.com"),
+				new TestCaseData ("aa..aa@example.com"),
+				new TestCaseData (".aaaa@example.com"),
+
+				// More not compliant with RFC
+				// Does not correspond now.
+				//new TestCaseData ("アドレス <aa\"aa@example.com>"),
+				//new TestCaseData ("\"アド\"レス\" <aaaa@example.com>"),
+				//new TestCaseData ("ア,ド;レ.ス@あ-ど-れ_す")
+			};
+			return addressList;
+		}
+
+		[TestCaseSource ("LegacyAddressNotCompliantWithRFC")]
+		public void TestLegacyEmailAddress (string address)
+		{
+			string text = address;
+
+			AssertParse (text);
+		}
+		#endregion
 	}
 }

--- a/UnitTests/MailboxAddressTests.cs
+++ b/UnitTests/MailboxAddressTests.cs
@@ -584,5 +584,134 @@ namespace UnitTests {
 		}
 
 		#endregion
+
+		#region TestLegacyEmailAddress
+		TestCaseData[] LegacyAddressNotCompliantWithRFC ()
+		{
+			var addressList = new TestCaseData[]
+			{
+				// RFCCompliance
+				new TestCaseData ("aaaa@example.com"),
+				new TestCaseData ("aa.aa@example.com"),
+				new TestCaseData ("0123456789@example.com"),
+				new TestCaseData ("abcdefghijklmnopqrstuvwxyz@example.com"),
+				new TestCaseData ("ABCDEFGHIJKLMNOPQRSTUVWXYZ@example.com"),
+				new TestCaseData ("a.a-a_a@ex-amp_le.com"),
+				new TestCaseData ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com"),
+				new TestCaseData ("アドレス <aaaa@example.com>"),
+				new TestCaseData ("アドレス<aaaa@example.com>"),
+				new TestCaseData ("\"アドレス\" <aaaa@example.com>"),
+				new TestCaseData ("\"アドレス\"   <aaaa@example.com>"),
+				new TestCaseData ("\"アドレス\"<aaaa@example.com>"),
+				new TestCaseData ("aaaa@example.com (アドレス)"),
+				new TestCaseData ("aaaa@example.com   (アドレス)"),
+				new TestCaseData ("aaaa@example.com(アドレス)"),
+				new TestCaseData ("0123456789 <aaaa@example.com>"),
+				new TestCaseData ("abcdefghijklmnopqrstuvwxyz <aaaa@example.com>"),
+				new TestCaseData ("ABCDEFGHIJKLMNOPQRSTUVWXYZ <aaaa@example.com>"),
+				new TestCaseData ("a.a@a-a_a <aaaa@example.com>"),
+				new TestCaseData ("bbb@example.com <aaaa@example.com>"),
+				new TestCaseData ("%22%3E%3C%28%29%5C <aaaa@example.com>"),
+				new TestCaseData ("\"%22%3E%3C%28%29%5C\" <aaaa@example.com>"),
+				new TestCaseData ("aaaa@example.com (%22%3E%3C%28%29%5C)"),
+				new TestCaseData ("aa!aa@example.com"),
+				new TestCaseData ("aa#aa@example.com"),
+				new TestCaseData ("aa$aa@example.com"),
+				new TestCaseData ("aa%aa@example.com"),
+				new TestCaseData ("aa&aa@example.com"),
+				new TestCaseData ("aa'aa@example.com"),
+				new TestCaseData ("aa*aa@example.com"),
+				new TestCaseData ("aa+aa@example.com"),
+				new TestCaseData ("aa/aa@example.com"),
+				new TestCaseData ("aa=aa@example.com"),
+				new TestCaseData ("aa?aa@example.com"),
+				new TestCaseData ("aa^aa@example.com"),
+				new TestCaseData ("aa`aa@example.com"),
+				new TestCaseData ("aa{aa@example.com"),
+				new TestCaseData ("aa|aa@example.com"),
+				new TestCaseData ("aa}aa@example.com"),
+				new TestCaseData ("aa~aa@example.com"),
+				new TestCaseData ("aa%20aa@example.com"),
+				new TestCaseData ("aa%21aa@example.com"),
+				new TestCaseData ("aa%23aa@example.com"),
+				new TestCaseData ("aa%24aa@example.com"),
+				new TestCaseData ("aa%25aa@example.com"),
+				new TestCaseData ("aa%26aa@example.com"),
+				new TestCaseData ("aa%27aa@example.com"),
+				new TestCaseData ("aa%2Aaa@example.com"),
+				new TestCaseData ("aa%2Baa@example.com"),
+				new TestCaseData ("aa%2Faa@example.com"),
+				new TestCaseData ("aa%3Daa@example.com"),
+				new TestCaseData ("aa%3Faa@example.com"),
+				new TestCaseData ("aa%5Eaa@example.com"),
+				new TestCaseData ("aa%60aa@example.com"),
+				new TestCaseData ("aa%7Baa@example.com"),
+				new TestCaseData ("aa%7Caa@example.com"),
+				new TestCaseData ("aa%7Daa@example.com"),
+				new TestCaseData ("aa%7Eaa@example.com"),
+				new TestCaseData ("aa%00aa@example.com"),
+				new TestCaseData ("aa%7Faa@example.com"),
+				new TestCaseData ("アドレス <aa!aa@example.com>"),
+				new TestCaseData ("アドレス <aa#aa@example.com>"),
+				new TestCaseData ("アドレス <aa$aa@example.com>"),
+				new TestCaseData ("アドレス <aa%aa@example.com>"),
+				new TestCaseData ("アドレス <aa&aa@example.com>"),
+				new TestCaseData ("アドレス <aa'aa@example.com>"),
+				new TestCaseData ("アドレス <aa*aa@example.com>"),
+				new TestCaseData ("アドレス <aa+aa@example.com>"),
+				new TestCaseData ("アドレス <aa/aa@example.com>"),
+				new TestCaseData ("アドレス <aa=aa@example.com>"),
+				new TestCaseData ("アドレス <aa?aa@example.com>"),
+				new TestCaseData ("アドレス <aa^aa@example.com>"),
+				new TestCaseData ("アドレス <aa`aa@example.com>"),
+				new TestCaseData ("アドレス <aa{aa@example.com>"),
+				new TestCaseData ("アドレス <aa|aa@example.com>"),
+				new TestCaseData ("アドレス <aa}aa@example.com>"),
+				new TestCaseData ("アドレス <aa~aa@example.com>"),
+				new TestCaseData ("アドレス <aa%21aa@example.com>"),
+				new TestCaseData ("アドレス <aa%22aa@example.com>"),
+				new TestCaseData ("アドレス <aa%23aa@example.com>"),
+				new TestCaseData ("アドレス <aa%24aa@example.com>"),
+				new TestCaseData ("アドレス <aa%25aa@example.com>"),
+				new TestCaseData ("アドレス <aa%26aa@example.com>"),
+				new TestCaseData ("アドレス <aa%27aa@example.com>"),
+				new TestCaseData ("アドレス <aa%2Aaa@example.com>"),
+				new TestCaseData ("アドレス <aa%2Baa@example.com>"),
+				new TestCaseData ("アドレス <aa%2Faa@example.com>"),
+				new TestCaseData ("アドレス <aa%3Daa@example.com>"),
+				new TestCaseData ("アドレス <aa%3Faa@example.com>"),
+				new TestCaseData ("アドレス <aa%5Eaa@example.com>"),
+				new TestCaseData ("アドレス <aa%60aa@example.com>"),
+				new TestCaseData ("アドレス <aa%7Baa@example.com>"),
+				new TestCaseData ("アドレス <aa%7Caa@example.com>"),
+				new TestCaseData ("アドレス <aa%7Daa@example.com>"),
+				new TestCaseData ("アドレス <aa%7Eaa@example.com>"),
+				new TestCaseData ("\"アド<>レス\" <aaaa@example.com>"),
+				new TestCaseData ("\"アド()レス\" <aaaa@example.com>"),
+				new TestCaseData ("ADDRESS012345"),
+				new TestCaseData ("アドレス０１２３４５"),
+
+				// Not compliant with RFC
+				new TestCaseData ("aaaa.@example.com"),
+				new TestCaseData ("aa..aa@example.com"),
+				new TestCaseData (".aaaa@example.com"),
+
+				// More not compliant with RFC
+				// Does not correspond now.
+				//new TestCaseData ("アドレス <aa\"aa@example.com>"),
+				//new TestCaseData ("\"アド\"レス\" <aaaa@example.com>"),
+				//new TestCaseData ("ア,ド;レ.ス@あ-ど-れ_す")
+			};
+			return addressList;
+		}
+
+		[TestCaseSource ("LegacyAddressNotCompliantWithRFC")]
+		public void TestLegacyEmailAddress (string address)
+		{
+			string text = address;
+
+			AssertParse (text);
+		}
+		#endregion
 	}
 }


### PR DESCRIPTION
#134046：IMAPにて「xxx..x@ezweb.ne.jp」といったRFC違反のアドレスからメールを受信した際にアドレスが「不正フォーマット」と表示されてしまう
の修正を行いました。
修正内容はチケットに記載しています。